### PR TITLE
Pass a form directly to serialize and deserialize

### DIFF
--- a/spec/javascripts/deserialize.spec.js
+++ b/spec/javascripts/deserialize.spec.js
@@ -199,4 +199,19 @@ describe("deserializing an object into a form", function(){
     });
   });
 
+  describe("when given a form element instead of a view", function() {
+    var form;
+
+    beforeEach(function(){
+      form = $("<form><input type='text' name='foo' value='bar'></form>")[0];
+
+      Backbone.Syphon.deserialize(form, { foo: "bar" });
+    });
+
+    it("should set the input's value to the corresponding value in the given object", function(){
+      var result = $(form).find('input[name=foo]').val();
+      expect(result).toBe("bar");
+    });
+  });
+
 });

--- a/spec/javascripts/serialize.spec.js
+++ b/spec/javascripts/serialize.spec.js
@@ -211,4 +211,19 @@ describe("serializing a form", function(){
     });
   });
 
+  describe("when given a form element instead of a view", function() {
+
+    var result;
+
+    beforeEach(function() {
+      form = $("<form><input type='text' name='foo' value='bar'></form>")[0];
+
+      result = Backbone.Syphon.serialize(form);
+    });
+
+    it("retrieves the inputs' values", function() {
+      expect(result.foo).toBe("bar");
+    });
+  });
+
 });

--- a/src/backbone.syphon.js
+++ b/src/backbone.syphon.js
@@ -12,7 +12,9 @@ Backbone.Syphon = (function(Backbone, $, _){
   // ------
 
   // Get a JSON object that represents
-  // all of the form inputs, in this view
+  // all of the form inputs, in this view.
+  // Alternately, pass a form element directly
+  // in place of the view.
   Syphon.serialize = function(view, options){
     var data = {};
 
@@ -48,7 +50,9 @@ Backbone.Syphon = (function(Backbone, $, _){
   };
   
   // Use the given JSON object to populate
-  // all of the form inputs, in this view
+  // all of the form inputs, in this view.
+  // Alternately, pass a form element directly
+  // in place of the view.
   Syphon.deserialize = function(view, data, options){
     // Build the configuration
     var config = buildConfig(options);
@@ -75,9 +79,9 @@ Backbone.Syphon = (function(Backbone, $, _){
   // -------
 
   // Retrieve all of the form inputs
-  // from the view
+  // from the form
   var getInputElements = function(view, config){
-    var form = view.$el.is("form") ? view.el : view.$("form")[0];
+    var form = getForm(view);
     var elements = form.elements;
 
     elements = _.reject(elements, function(el){
@@ -131,6 +135,16 @@ Backbone.Syphon = (function(Backbone, $, _){
     return type.toLowerCase();
   };
   
+  // If a form element is given, just return it. 
+  // Otherwise, get the form element from the view.
+  var getForm = function(viewOrForm){
+    if (_.isUndefined(viewOrForm.$el) && viewOrForm.tagName.toLowerCase() === 'form'){
+      return viewOrForm;
+    } else {
+      return viewOrForm.$el.is("form") ? viewOrForm.el : viewOrForm.$("form")[0];
+    }
+  }
+
   // Build a configuration object and initialize
   // default values.
   var buildConfig = function(options){


### PR DESCRIPTION
Allow a form element to be passed directly to Syphon.serialize and
Syphon.deserialize as the first argument.
