### PR TITLE
Form tag no longer required in view and disabled fields are ignored

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -480,7 +480,6 @@ For more information on Key Assignment Validators, see the full
 There some known limitations in Backbone.Syphon, partially by design and
 partially implemented as default behaivors. 
 
-* You must have a `<form>` within your view's `$el`
 * An input of type `checkbox` will return a boolean value. This can be
 overriden by replacing the Input Reader for checkboxes.
 

--- a/spec/javascripts/deserialize.spec.js
+++ b/spec/javascripts/deserialize.spec.js
@@ -214,4 +214,28 @@ describe("deserializing an object into a form", function(){
     });
   });
 
+
+  describe("when deserializing without a form", function(){
+    var View = Backbone.View.extend({
+      render: function(){
+        this.$el.html("<input type='text' name='foo'>");
+      }
+    });
+
+    var view;
+
+    beforeEach(function(){
+      view = new View();
+      view.render();
+
+      Backbone.Syphon.deserialize(view, { foo: "bar" });
+    });
+
+    it("should set the input's value", function(){
+      var result = view.$('input[name=foo]').val();
+      expect(result).toBe("bar");
+    });
+  });
+
+
 });

--- a/spec/javascripts/serialize.spec.js
+++ b/spec/javascripts/serialize.spec.js
@@ -213,6 +213,58 @@ describe("serializing a form", function(){
     });
   });
 
+  describe("when serializing forms with disabled text fields", function(){
+    var View = Backbone.View.extend({
+      render: function(){
+        this.$el.html("<form><input type='text' name='foo' value='bar'><input type='text' name='ignore' value='bar' disabled></form>");
+      }
+    });
+
+    var view, result;
+
+    beforeEach(function(){
+      view = new View();
+      view.render();
+
+      result = Backbone.Syphon.serialize(view);
+    });
+
+    it("should return an object with a key from the text input name, and ignore disabled", function(){
+      expect(result.hasOwnProperty("foo")).toBe(true)
+      expect(result.hasOwnProperty("ignore")).toBe(false)
+    });
+
+    it("should have the input's value", function(){
+      expect(result.foo).toBe("bar");
+    });
+  });
+
+  describe("when serializing forms with disabled select field", function(){
+    var View = Backbone.View.extend({
+      render: function(){
+        this.$el.html("<form><input type='text' name='foo' value='bar'><select name='ignore' disabled='disabled'><option selected='selected' value='bar'>bar</option><option value='bar2'>bar2</option></select></form>");
+      }
+    });
+
+    var view, result;
+
+    beforeEach(function(){
+      view = new View();
+      view.render();
+
+      result = Backbone.Syphon.serialize(view);
+    });
+
+    it("should return an object with a key from the text input name, and ignore disabled", function(){
+      expect(result.hasOwnProperty("foo")).toBe(true)
+      expect(result.hasOwnProperty("ignore")).toBe(false)
+    });
+
+    it("should have the input's value", function(){
+      expect(result.foo).toBe("bar");
+    });
+  });
+
   describe("when the view is actually a form", function() {
     var View = Backbone.View.extend({
       tagName: "form",
@@ -241,6 +293,25 @@ describe("serializing a form", function(){
       form = $("<form><input type='text' name='foo' value='bar'></form>")[0];
 
       result = Backbone.Syphon.serialize(form);
+    });
+
+    it("retrieves the inputs' values", function() {
+      expect(result.foo).toBe("bar");
+    });
+  });
+
+  describe("when the view does not contain a form", function() {
+    var View = Backbone.View.extend({
+      render: function(){
+        this.$el.html("<input type='text' name='foo' value='bar'>");
+      }
+    });
+
+    beforeEach(function() {
+      view = new View();
+      view.render();
+
+      result = Backbone.Syphon.serialize(view);
     });
 
     it("retrieves the inputs' values", function() {

--- a/src/backbone.syphon.js
+++ b/src/backbone.syphon.js
@@ -100,7 +100,7 @@ Backbone.Syphon = (function(Backbone, $, _){
 
     elements = _.reject(elements, function(el){
       // Reject disabled fields always
-      if (el.hasAttribute('disabled')) return true;
+      if (el.hasAttribute('disabled')) { return true; }
 
       var reject;
       var type = getElementType(el);

--- a/src/backbone.syphon.js
+++ b/src/backbone.syphon.js
@@ -89,14 +89,24 @@ Backbone.Syphon = (function(Backbone, $, _){
   // from the form
   var getInputElements = function(view, config){
     var form = getForm(view);
-    var elements = form.elements;
+    var elements;
+
+    if (form) {
+      elements = form.elements;
+    } else {
+      // fallback on :input selector
+      elements = view.$(':input');
+    }
 
     elements = _.reject(elements, function(el){
+      // Reject disabled fields always
+      if (el.hasAttribute('disabled')) return true;
+
       var reject;
       var type = getElementType(el);
       var extractor = config.keyExtractors.get(type);
       var identifier = extractor($(el));
-     
+
       var foundInIgnored = _.include(config.ignoredTypes, type);
       var foundInInclude = _.include(config.include, identifier);
       var foundInExclude = _.include(config.exclude, identifier);


### PR DESCRIPTION
This is a remake of my previous pull request #9 for the latest release (0.4.1).

If a form tag is not found in the view, the $(':input') selector will be used instead to find all input fields.

Additionally, disabled fields will be completely ignored, to more closely match a regular HTML form.

Cheers,
sam