### PR TITLE
Don't blow up if form tag can't be found

### DIFF
--- a/spec/javascripts/deserialize.spec.js
+++ b/spec/javascripts/deserialize.spec.js
@@ -1,4 +1,22 @@
 describe("deserializing an object into a form", function(){
+  describe("when the form tag cannot be found", function(){
+    var View = Backbone.View.extend({
+      render: function(){
+        this.$el.html("<input type='text' name='foo'>");
+      }
+    });
+
+    var view;
+
+    beforeEach(function(){
+      view = new View();
+      view.render();
+    });
+
+    it("should not throw an exception", function(){
+      expect(function(){ Backbone.Syphon.deserialize(view, { foo: "bar" }) }).not.toThrow();
+    });
+  });
 
   describe("when deserializing into a text input", function(){
     var View = Backbone.View.extend({

--- a/spec/javascripts/serialize.spec.js
+++ b/spec/javascripts/serialize.spec.js
@@ -1,4 +1,22 @@
 describe("serializing a form", function(){
+  describe("when the form tag cannot be found", function(){
+    var View = Backbone.View.extend({
+      render: function(){
+        this.$el.html("<input type='text' name='foo' value='bar'>");
+      }
+    });
+
+    var view;
+
+    beforeEach(function(){
+      view = new View();
+      view.render();
+    });
+
+    it("should not throw an exception", function(){
+      expect(function(){ Backbone.Syphon.serialize(view) }).not.toThrow();
+    });
+  });
   
   describe("when serializing a text input", function(){
     var View = Backbone.View.extend({

--- a/src/backbone.syphon.js
+++ b/src/backbone.syphon.js
@@ -89,7 +89,7 @@ Backbone.Syphon = (function(Backbone, $, _){
   // from the form
   var getInputElements = function(view, config){
     var form = getForm(view);
-    var elements = form.elements;
+    var elements = form && form.elements || [];
 
     elements = _.reject(elements, function(el){
       var reject;


### PR DESCRIPTION
This is a small change to prevent ```serialize``` and ```deserialize``` from blowing up if a ```<form>``` can't be found.

I could outline my use case to motivate if you like, but hopefully the added robustness will be sufficient in itself?

Any thoughts?