### PR TITLE
Fix variable scope

### DIFF
--- a/src/backbone.syphon.keysplitter.js
+++ b/src/backbone.syphon.keysplitter.js
@@ -9,6 +9,7 @@
 // `<input name="foo.bar.baz">`, `return key.split(".")`
 Backbone.Syphon.KeySplitter = function(key){
   var matches = key.match(/[^\[\]]+/g);
+  var lastKey;
 
   if (key.indexOf("[]") === key.length - 2){
     lastKey = matches.pop();


### PR DESCRIPTION
Prevents `lastKey` variable from polluting the global scope.
