### PR TITLE
fix #17 End keysplitter and keyjoiner functions with semicolon

### DIFF
--- a/src/backbone.syphon.keyjoiner.js
+++ b/src/backbone.syphon.keyjoiner.js
@@ -17,4 +17,4 @@
 
 Backbone.Syphon.KeyJoiner = function(parentKey, childKey){
   return parentKey + "[" + childKey + "]";
-}
+};

--- a/src/backbone.syphon.keysplitter.js
+++ b/src/backbone.syphon.keysplitter.js
@@ -16,4 +16,4 @@ Backbone.Syphon.KeySplitter = function(key){
   }
 
   return matches;
-}
+};


### PR DESCRIPTION
Prevents errors when joining multiple scripts
