### PR TITLE
Fix Package.json license

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,12 @@
     "client",
     "browser"
   ],
-  "license": "https://github.com/marionettejs/backbone.syphon/blob/master/LICENSE.md",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/marionettejs/backbone.syphon/blob/master/LICENSE.md"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/marionettejs/backbone.syphon.git"


### PR DESCRIPTION
Fixes the package.json license. https://www.npmjs.org/package/backbone.syphon
