### PR TITLE
Flatten array of objects correctly

### DIFF
--- a/src/backbone.syphon.js
+++ b/src/backbone.syphon.js
@@ -259,8 +259,7 @@ var flattenData = function(config, data, parentKey){
     }
 
     if (_.isArray(value)){
-      keyName += '[]';
-      hash[keyName] = value;
+      hash = flattenData(config, value, keyName);
     } else if (_.isObject(value)){
       hash = flattenData(config, value, keyName);
     } else {


### PR DESCRIPTION
Given this JSON file:

```
   {
   "id":9,
   "namn":"CM 41",
   "artnr":70184628167,
   "beskr":"text",
   "title":"",
   "description":"",
   "typ":"1",
   "colorcode":0,
   "pris":12330,
   "img":"MasonrySaw_CM_41",
   "data":[
      {
         "id_data_info":2,
         "id_data_vrde":2,
         "info_text":"Spänning",
         "vrde_text":"230 V"
      },
      {
         "id_data_info":3,
         "id_data_vrde":70,
         "info_text":"Effekt",
         "vrde_text":"2,2 kW (3 Hk)"
      }
   ],
   "bladerecommendations":[

   ],
   "numbers-array":[
         1,
         2,
         3
   ],
   "strings-array":[
         "one",
         "two",
         "three"
   ]
}
```

The current implementation of flattenData gives the following in return:

```
{
   "id":9,
   "namn":"CM 41",
   "artnr":70184628167,
   "beskr":"text",
   "title":"",
   "description":"",
   "typ":"1",
   "colorcode":0,
   "pris":12330,
   "img":"MasonrySaw_CM_41",
   "data[]":[
      {
         "id_data_info":2,
         "id_data_vrde":2,
         "info_text":"Spänning",
         "vrde_text":"230 V"
      },
      {
         "id_data_info":3,
         "id_data_vrde":70,
         "info_text":"Effekt",
         "vrde_text":"2,2 kW (3 Hk)"
      }
   ],
   "propertys[]":[

   ],
   "bladerecommendations[]":[

   ],
   "uProducts[]":[

   ],
   "na[]":[
      1,
      2,
      3
   ],
   "sa[]":[
      "one",
      "two",
      "three"
   ],
   "active":false
}
```

If the value is an `Array` it should be sent to `flattenData` again, same as if it is an `Object`. This change gives the following return.

```
{
   "id":9,
   "namn":"CM 41",
   "artnr":70184628167,
   "beskr":"text",
   "title":"",
   "description":"",
   "typ":"1",
   "colorcode":0,
   "pris":12330,
   "img":"MasonrySaw_CM_41",
   "data[0][id_data_info]":2,
   "data[0][id_data_vrde]":2,
   "data[0][info_text]":"Spänning",
   "data[0][vrde_text]":"230 V",
   "data[1][id_data_info]":3,
   "data[1][id_data_vrde]":70,
   "data[1][info_text]":"Effekt",
   "data[1][vrde_text]":"2,2 kW (3 Hk)"
   "na[0]":1,
   "na[1]":2,
   "na[2]":3,
   "sa[0]":"one",
   "sa[1]":"two",
   "sa[2]":"three",
   "active":false
}
```
