### PR TITLE
fix(Syphon.KeySplitter): allow one character names

### DIFF
--- a/src/backbone.syphon.keysplitter.js
+++ b/src/backbone.syphon.keysplitter.js
@@ -11,7 +11,7 @@ Syphon.KeySplitter = function(key) {
   var matches = key.match(/[^\[\]]+/g);
   var lastKey;
 
-  if (key.indexOf('[]') === key.length - 2) {
+  if (key.length > 1 && key.indexOf('[]') === key.length - 2) {
     lastKey = matches.pop();
     matches.push([lastKey]);
   }


### PR DESCRIPTION
Hey there, 

before this :

``` html
<input name="q" value="asdf">
```

Will give 

``` javascript
> data.q
<- ["asf"] 
```

Now it gives, 

``` javascript
> data.q
<- "asf"
```

Cheers !
