### PR TITLE
Fixes #78

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,10 @@
   },
   "dependencies": {
     "jquery": "^1.8.0 || ^2.1.0",
-    "backbone" : "^1.1.0",
-    "underscore": "^1.6.0"
+    "backbone": "1.0.0 - 1.1.2",
+    "underscore": "1.4.4 - 1.6.0"
   },
   "devDependencies": {
-    "backbone": "1.1.2",
     "chai": "^1.9.1",
     "chai-jquery": "^1.2.3",
     "grunt": "^0.4.4",
@@ -51,12 +50,10 @@
     "grunt-mocha-test": "^0.11.0",
     "grunt-preprocess": "^4.0.0",
     "grunt-template": "^0.2.3",
-    "jquery": "^2.1.1",
     "jsdom": "^0.11.0",
     "load-grunt-tasks": "^0.4.0",
     "mocha": "^1.20.1",
     "sinon": "^1.10.2",
-    "sinon-chai": "^2.5.0",
-    "underscore": "1.6.0"
+    "sinon-chai": "^2.5.0"    
   }
 }


### PR DESCRIPTION
Moves jQuery, backbone and underscore to `dependencies`
Updates version ranges to match backbone.marionete#master