### PR TITLE
An indeterminate checkbox will be a null value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ By default, a checkbox will return a boolean value signifying whether or not it 
 <form>
   <input type="checkbox" name="a">
   <input type="checkbox" name="b" checked>
+  <input type="checkbox" name="c" indeterminate>
 </form>
 ```
 
@@ -133,7 +134,8 @@ Backbone.Syphon.serialize(view);
 
 {
   a: false,
-  b: true
+  b: true,
+  c: null
 }
 ```
 

--- a/spec/javascripts/deserialize.spec.js
+++ b/spec/javascripts/deserialize.spec.js
@@ -137,6 +137,21 @@ describe('deserializing an object into a form', function() {
         expect(this.result).to.be.false;
       });
     });
+
+    describe('and the corresponding value in the given object is null', function() {
+      beforeEach(function() {
+        this.view = new this.View();
+        this.view.render();
+        this.view.$('#the-checkbox').prop('checked', false);
+
+        Backbone.Syphon.deserialize(this.view, {chk: null});
+        this.result = this.view.$('#the-checkbox').prop('indeterminate');
+      });
+
+      it('should add an indeterminate attribute', function() {
+        expect(this.result).to.be.true;
+      });
+    });
   });
 
   describe('when deserializing into a button', function() {

--- a/spec/javascripts/serialize.spec.js
+++ b/spec/javascripts/serialize.spec.js
@@ -158,6 +158,20 @@ describe('serializing a form', function() {
         expect(this.result.chk).to.be.false;
       });
     });
+
+    describe('and the checkbox is indeterminate', function() {
+      beforeEach(function() {
+        this.view = new this.View();
+        this.view.render();
+        this.view.$('#the-checkbox').prop('indeterminate', true);
+
+        this.result = Backbone.Syphon.serialize(this.view);
+      });
+
+      it('should return an object with a value of null', function() {
+        expect(this.result.chk).to.be.null;
+      });
+    });
   });
 
   describe('when serializing a button', function() {

--- a/src/backbone.syphon.inputreaders.js
+++ b/src/backbone.syphon.inputreaders.js
@@ -17,5 +17,5 @@ InputReaders.registerDefault(function($el) {
 // Checkbox reader, returning a boolean value for
 // whether or not the checkbox is checked.
 InputReaders.register('checkbox', function($el) {
-  return $el.prop('checked');
+  return ($el.prop('indeterminate')) ? null : $el.prop('checked');
 });

--- a/src/backbone.syphon.inputwriters.js
+++ b/src/backbone.syphon.inputwriters.js
@@ -17,7 +17,11 @@ InputWriters.registerDefault(function($el, value) {
 // Checkbox writer, set whether or not the checkbox is checked
 // depending on the boolean value.
 InputWriters.register('checkbox', function($el, value) {
-  $el.prop('checked', value);
+  if (value === null) {
+    $el.prop('indeterminate', true);
+  } else {
+    $el.prop('checked', value);
+  }
 });
 
 // Radio button writer, set whether or not the radio button is


### PR DESCRIPTION
This is #76 with tests.

It provides the checkbox indeterminate attribute as a null when serializing and deserializing.