### PR TITLE
Reject disabled fields

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -478,7 +478,7 @@ For more information on Key Assignment Validators, see the full
 ## Current Limitations
 
 There some known limitations in Backbone.Syphon, partially by design and
-partially implemented as default behaivors. 
+partially implemented as default behaviors. 
 
 * You must have a `<form>` within your view's `$el`
 * An input of type `checkbox` will return a boolean value. This can be

--- a/readme.md
+++ b/readme.md
@@ -477,8 +477,8 @@ For more information on Key Assignment Validators, see the full
 
 ## Current Limitations
 
-There some known limitations in Backbone.Syphon, partially by design and
-partially implemented as default behaviors. 
+There are some known limitations in Backbone.Syphon, partially by design and
+partially implemented as default behavior. 
 
 * You must have a `<form>` within your view's `$el`
 * An input of type `checkbox` will return a boolean value. This can be

--- a/spec/javascripts/serialize.spec.js
+++ b/spec/javascripts/serialize.spec.js
@@ -269,4 +269,56 @@ describe('serializing a form', function() {
       expect(this.result.foo).to.equal('bar');
     });
   });
+  
+  describe("when serializing forms with disabled text fields", function(){
+    var View = Backbone.View.extend({
+      render: function(){
+        this.$el.html("<form><input type='text' name='foo' value='bar'><input type='text' name='ignore' value='bar' disabled></form>");
+      }
+    });
+
+    var view, result;
+
+    beforeEach(function(){
+      view = new View();
+      view.render();
+
+      result = Backbone.Syphon.serialize(view);
+    });
+
+    it("should return an object with a key from the text input name, and ignore disabled", function(){
+      expect(result.hasOwnProperty("foo")).toBe(true)
+      expect(result.hasOwnProperty("ignore")).toBe(false)
+    });
+
+    it("should have the input's value", function(){
+      expect(result.foo).toBe("bar");
+    });
+  });
+
+  describe("when serializing forms with disabled select field", function(){
+    var View = Backbone.View.extend({
+      render: function(){
+        this.$el.html("<form><input type='text' name='foo' value='bar'><select name='ignore' disabled='disabled'><option selected='selected' value='bar'>bar</option><option value='bar2'>bar2</option></select></form>");
+      }
+    });
+
+    var view, result;
+
+    beforeEach(function(){
+      view = new View();
+      view.render();
+
+      result = Backbone.Syphon.serialize(view);
+    });
+
+    it("should return an object with a key from the text input name, and ignore disabled", function(){
+      expect(result.hasOwnProperty("foo")).toBe(true)
+      expect(result.hasOwnProperty("ignore")).toBe(false)
+    });
+
+    it("should have the input's value", function(){
+      expect(result.foo).toBe("bar");
+    });
+  });
 });

--- a/src/backbone.syphon.js
+++ b/src/backbone.syphon.js
@@ -91,6 +91,9 @@ var getInputElements = function(view, config){
   var elements = form.elements;
 
   elements = _.reject(elements, function(el){
+    // Reject disabled fields always
+    if (el.hasAttribute('disabled')) { return true; }    
+    
     var reject;
     var type = getElementType(el);
     var extractor = config.keyExtractors.get(type);


### PR DESCRIPTION
The travis failure seems to be incorrect.  It reports the error as: 

src/backbone.syphon.js
     93 |  elements = _.reject(elements, function(el){
                                                 ^ This function has too many statements. (15)

But that is code both unchanged in this request and the correct function signature for underscore and lodash's _.reject method.  Am I understanding this incorrectly? 