### PR TITLE
Serialize multi-select values as an array

### DIFF
--- a/spec/javascripts/serialize.spec.js
+++ b/spec/javascripts/serialize.spec.js
@@ -114,8 +114,35 @@ describe('serializing a form', function() {
       this.result = Backbone.Syphon.serialize(this.view);
     });
 
-    it('should have the textarea\'s value', function() {
+    it('should return the selected option value', function() {
       expect(this.result.foo).to.equal('bar');
+    });
+  });
+
+  describe('when serializing a multi-select box', function() {
+    beforeEach(function() {
+      this.View = Backbone.View.extend({
+        render: function() {
+          this.$el.html(
+              '<form>' +
+              '<select name="foo[]" multiple="multiple">' +
+              '<option value="bar1" selected="selected">Bar 1</option>' +
+              '<option value="bar2">Bar 2</option>' +
+              '<option value="bar3" selected="selected">Bar 3</option>' +
+              '</select>' +
+              '</form>'
+          );
+        }
+      });
+
+      this.view = new this.View();
+      this.view.render();
+
+      this.result = Backbone.Syphon.serialize(this.view);
+    });
+
+    it('should return the selected options values', function() {
+      expect(this.result.foo).to.deep.equal(['bar1', 'bar3']);
     });
   });
 

--- a/src/backbone.syphon.js
+++ b/src/backbone.syphon.js
@@ -202,11 +202,15 @@ var assignKeyValue = function(obj, keychain, value) {
 
   // if it's the last key in the chain, assign the value directly
   if (keychain.length === 0) {
-    if (_.isArray(obj[key])) {
-      obj[key].push(value);
-    } else {
-      obj[key] = value;
-    }
+    value = _.isArray(value) ? value : [value];
+
+    _.each(value, function(v) {
+      if (_.isArray(obj[key])) {
+        obj[key].push(v);
+      } else {
+        obj[key] = v;
+      }
+    });
   }
 
   // recursive parsing of the array, depth-first


### PR DESCRIPTION
Hi,

I have a multi-select in one of my forms. I started using Backbone.Syphon to serialize that form and I realized that it wasn't returning the values I am expecting. Before this change, it's returning the values of a multi-select in a nested array:

```javascript
[
  [
    "bar1",
    "bar2"
  ]
]
```

When submitting this format of serialized data to my backend (using Rails) via AJAX, the URL encoded value will be `foo%5B0%5D%5B%5D=bar1&foo%5B0%5D%5B%5D=bar2`. That looks weird and that's not what I am expecting.

My expected output is:

```javascript
[
  "bar1",
  "bar2"
]
```

Which will be `foo%5B%5D=bar1&foo%5B%5D=bar2` when URL encoded.

Regarding the fix found in this pull request, I updated the `assignKeyValue` method to push each value into the array instead of pushing the array into an array to avoid the nested array output. I also added a spec for that and hopefully that helps in explaining my case further. All tests are still passing with these changes.

If I'm still missing something or if I need to change something else, please let me know. :)

Thanks,
Patrick