### PR TITLE
Use `$.find`, not `$.children`, to parse nested inputs within a specific form

### DIFF
--- a/spec/javascripts/serialize.spec.js
+++ b/spec/javascripts/serialize.spec.js
@@ -306,6 +306,24 @@ describe('serializing a form', function() {
     });
   });
 
+  describe('when given a form element with nested inputs', function() {
+    beforeEach(function() {
+      this.form = $(
+          '<form>' +
+          '<div>' +
+          '<input type="text" name="foo" value="bar">' +
+          '</div>' +
+          '</form>'
+      )[0];
+
+      this.result = Backbone.Syphon.serialize(this.form);
+    });
+
+    it('retrieves the inputs\' values', function() {
+      expect(this.result.foo).to.equal('bar');
+    });
+  });
+
   describe('when given more than 1 form', function() {
     beforeEach(function() {
       this.View = Backbone.View.extend({

--- a/src/backbone.syphon.js
+++ b/src/backbone.syphon.js
@@ -147,7 +147,7 @@ var getElementType = function(el) {
 // Otherwise, get the form fields from the view.
 var getForm = function(viewOrForm) {
   if (_.isUndefined(viewOrForm.$el)) {
-    return $(viewOrForm).children(':input');
+    return $(viewOrForm).find(':input');
   } else {
     return viewOrForm.$(':input');
   }


### PR DESCRIPTION
*Reopening against minor*

This updates `getForm` to rely on `$.find`, not `$.children`, when searching for inputs within a specific form (not a view). That's consistent with how it handles inputs within a view (`View.$`, which is the equivalent of `$.find`), and it lets Syphon pull data from inputs nested more than one level down, like `<div><input></input></div>`. Fixes https://github.com/marionettejs/backbone.syphon/issues/104 .

/cc @rhubarbselleven 

Marionette: 2.4.1 / Syphon: 0.6.0