### PR TITLE
relax backbone and underscore dependencies

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -7,9 +7,9 @@
     <link rel="stylesheet" href="node_modules/mocha/mocha.css" />
     <script src="node_modules/mocha/mocha.js"></script>
 
-    <script src="bower_components/jquery/dist/jquery.js"></script>
-    <script src="bower_components/underscore/underscore.js"></script>
-    <script src="bower_components/backbone/backbone.js"></script>
+    <script src="node_modules/jquery/dist/jquery.js"></script>
+    <script src="node_modules/underscore/underscore.js"></script>
+    <script src="node_modules/backbone/backbone.js"></script>
 
     <script src="node_modules/chai/chai.js"></script>
     <script src="node_modules/sinon/pkg/sinon.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -24,8 +24,8 @@
   ],
   "dependencies": {
     "jquery": "^1.8.0 || ^2.1.0",
-    "backbone" : "^1.1.0",
-    "underscore": "^1.6.0"
+    "backbone" : "1.0.0 - 1.2.1",
+    "underscore": "1.4.4 - 1.8.3"
   },
   "ignore": [
     "apidoc.md",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "coverage": "grunt coverage --mocha-reporter=dot"
   },
   "dependencies": {
+    "backbone": "1.0.0 - 1.2.1",
     "jquery": "^1.8.0 || ^2.1.0",
-    "backbone": "1.0.0 - 1.1.2",
-    "underscore": "1.4.4 - 1.6.0"
+    "underscore": "1.4.4 - 1.8.3"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
browser tests are green after fixing the deps from bower to npm

I don't want to bundle multiple underscore/backbone
because of syphon being to constraining

Tested by building and opening the SpecRunner.html,
testing via node was broken for me because of something inside jsdom.