### PR TITLE
Update supported Backbone version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "jquery": "^1.8.0 || ^2.1.0",
-    "backbone" : "1.0.0 - 1.2.3",
+    "backbone" : "1.0.0 - 1.3.x",
     "underscore": "1.4.4 - 1.8.3"
   },
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "coverage": "grunt coverage --mocha-reporter=dot"
   },
   "dependencies": {
-    "backbone": "1.0.0 - 1.2.3",
+    "backbone": "1.0.0 - 1.3.x",
     "jquery": "^1.8.0 || ^2.1.0",
     "underscore": "1.4.4 - 1.8.3"
   },


### PR DESCRIPTION
This PR changes bower.json and package.json dependencies on Backbone to support 1.3.x

I chose to use 1.3.x rather than a more explicit 1.3.3 because @megawac asked for it over on Backbone.Base-Router, https://github.com/jmeas/backbone.base-router/commit/bb4837c57332d5e125928d4d3d3ca8ff0664cbbb#commitcomment-17756198

This PR doesn't bump the build version or anything like that. We'll need to cut a release ASAP after this is merged.