### PR TITLE
Fixed a couple of example typos

### DIFF
--- a/apidoc.md
+++ b/apidoc.md
@@ -27,7 +27,7 @@ MyExtractorSet.registerDefault(function($el){
   return $el.prop("id");
 });
 
-Backbone.KeyExtractors = MyExtractorSet;
+Backbone.Syphon.KeyExtractors = MyExtractorSet;
 ```
 
 Under normal circumstances, you won't have to replace
@@ -153,7 +153,7 @@ MyReaderSet.registerDefault(function($el){
   return $el.val();
 });
 
-Backbone.InputReaders = MyReaderSet;
+Backbone.Syphon.InputReaders = MyReaderSet;
 ```
 
 Under normal circumstances, you won't have to create your
@@ -216,7 +216,7 @@ MyWriterSet.registerDefault(function($el, value){
   $el.val(value);
 });
 
-Backbone.InputWriters = MyWriterSet;
+Backbone.Syphon.InputWriters = MyWriterSet;
 ```
 
 Under normal circumstances, you won't have to create your


### PR DESCRIPTION
In a number of examples custom properties were assigned to Backbone instead of overwriting those of Backbone.Syphon